### PR TITLE
Sphinx build error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ __pycache__/*
 
 # Package files
 *.egg
+.eggs
 .installed.cfg
 *.egg-info
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,10 +35,11 @@ apidoc.main(cmd_line.split(" "))
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['numpydoc', 'sphinx.ext.autodoc', 'sphinx.ext.autosummary',
-					'sphinx.ext.doctest', 'sphinx.ext.pngmath', 
-					'sphinx.ext.intersphinx', 'sphinx.ext.todo', 
-					'sphinx.ext.viewcode', 'sphinx.ext.coverage', 'sphinx.ext.ifconfig']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary',
+              'sphinx.ext.doctest', 'sphinx.ext.pngmath',
+              'sphinx.ext.intersphinx', 'sphinx.ext.todo',
+              'sphinx.ext.viewcode', 'sphinx.ext.coverage',
+              'sphinx.ext.ifconfig', 'numpydoc']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -107,7 +108,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,25 +4,7 @@ Numdifftools
 
 This is the documentation of **Numdifftools**.
 
-.. note::
-
-    This is the main page of your project's `Sphinx <http://sphinx-doc.org/>`_
-    documentation. It is formatted in `reStructuredText
-    <http://sphinx-doc.org/rest.html>`__. Add additional pages by creating
-    rst-files in ``docs`` and adding them to the `toctree
-    <http://sphinx-doc.org/markup/toctree.html>`_ below. Use then
-    `references <http://sphinx-doc.org/markup/inline.html>`__ in order to link
-    them from this page. It is also possible to refer to the documentation of
-    other Python packages with the `Python domain syntax
-    <http://sphinx-doc.org/domains.html#the-python-domain>`__. By default you
-    can reference the documentation of `Sphinx <http://sphinx.pocoo.org>`__,
-    `Python <http://docs.python.org/>`__, `matplotlib
-    <http://matplotlib.sourceforge.net>`__, `NumPy
-    <http://docs.scipy.org/doc/numpy>`__, `Scikit-Learn
-    <http://scikit-learn.org/stable>`__, `Pandas
-    <http://pandas.pydata.org/pandas-docs/stable>`__, `SciPy
-    <http://docs.scipy.org/doc/scipy/reference/>`__. You can add more by
-    extending the ``intersphinx_mapping`` in your Sphinx's ``conf.py``.
+Code and issue tracker is at https://github.com/pbrod/numdifftools .
 
 Contents
 ========


### PR DESCRIPTION
With Python 3.4 and Sphinx 1.3 I get the following error when I try to build the numdifftools docs:
```
$ python setup.py build_sphinx
/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/setuptools/dist.py:291: UserWarning: The version specified ('unknown') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
  "details." % self.metadata.version
running build_sphinx
Running Sphinx v1.3
Creating file /Users/deil/code/numdifftools/docs/../docs/_rst/numdifftools.rst.
Creating file /Users/deil/code/numdifftools/docs/../docs/_rst/numdifftools.tests.rst.
Creating file /Users/deil/code/numdifftools/docs/../docs/_rst/modules.rst.
Traceback (most recent call last):
  File "setup.py", line 229, in <module>
    setup_package()
  File "setup.py", line 226, in setup_package
    entry_points={'console_scripts': CONSOLE_SCRIPTS})
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/sphinx/setup_command.py", line 161, in run
    freshenv=self.fresh_env)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/sphinx/application.py", line 143, in __init__
    self.setup_extension(extension)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/sphinx/application.py", line 440, in setup_extension
    ext_meta = mod.setup(self)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/numpydoc/numpydoc.py", line 114, in setup
    app.connect('autodoc-process-docstring', mangle_docstrings)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/sphinx/application.py", line 471, in connect
    self._validate_event(event)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/sphinx/application.py", line 468, in _validate_event
    raise ExtensionError('Unknown event name: %s' % event)
sphinx.errors.ExtensionError: Unknown event name: autodoc-process-docstring
```

cc @maniteja123