### PR TITLE
Fix min version for numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Add your requirements here like:
-numpy>=1.4
+numpy>=1.9
 scipy>=0.8
 algopy>=0.4
 numpydoc>=0.5


### PR DESCRIPTION
numpy.nanmedia has been added in Numpy-1.9.0

https://docs.scipy.org/doc/numpy/release.html?highlight=nanmedian

Signed-off-by: Justin Lecher <jlec@gentoo.org>