### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/numdifftools/core.py
+++ b/numdifftools/core.py
@@ -229,9 +229,9 @@ class MinStepGenerator(object):
 
     def __repr__(self):
         class_name = self.__class__.__name__
-        kwds = ['%s=%s' % (name, str(getattr(self, name)))
+        kwds = ['{0!s}={1!s}'.format(name, str(getattr(self, name)))
                 for name in self.__dict__.keys()]
-        return """%s(%s)""" % (class_name, ','.join(kwds))
+        return """{0!s}({1!s})""".format(class_name, ','.join(kwds))
 
     def _default_scale(self, method, n, order):
         scale = self.scale
@@ -320,9 +320,9 @@ class MinMaxStepGenerator(object):
 
     def __repr__(self):
         class_name = self.__class__.__name__
-        kwds = ['%s=%s' % (name, str(getattr(self, name)))
+        kwds = ['{0!s}={1!s}'.format(name, str(getattr(self, name)))
                 for name in self.__dict__.keys()]
-        return """%s(%s)""" % (class_name, ','.join(kwds))
+        return """{0!s}({1!s})""".format(class_name, ','.join(kwds))
 
     def __call__(self, x, method='forward', n=1, order=None):
         if self.scale is not None:
@@ -579,7 +579,7 @@ class _Derivative(object):
         return der, info
 
     def _get_function_name(self):
-        name = '_%s' % self.method
+        name = '_{0!s}'.format(self.method)
         even_derivative_order = self._is_even_derivative()
         if even_derivative_order and self.method in ('central', 'complex'):
             name = name + '_even'
@@ -775,7 +775,7 @@ class Derivative(_Derivative):
         try:
             step = [1, 2, 2, 4, 4, 4, 4][parity]
         except Exception as e:
-            msg = '%s. Parity must be 0, 1, 2, 3, 4, 5 or 6! (%d)' % (str(e),
+            msg = '{0!s}. Parity must be 0, 1, 2, 3, 4, 5 or 6! ({1:d})'.format(str(e),
                                                                       parity)
             raise ValueError(msg)
         inv_sr = 1.0 / step_ratio

--- a/numdifftools/extrapolation.py
+++ b/numdifftools/extrapolation.py
@@ -181,7 +181,7 @@ def test_dea():
         x = linfun(k)
         val = np.trapz(np.sin(x), x)
         vale, err = dea(val)
-        print('%5d %20.8f  %20.8f  %20.8f' % (len(x)-1, val, vale, err))
+        print('{0:5d} {1:20.8f}  {2:20.8f}  {3:20.8f}'.format(len(x)-1, val, vale, err))
 
 
 def dea3(v0, v1, v2, symmetric=False):

--- a/numdifftools/limits.py
+++ b/numdifftools/limits.py
@@ -86,9 +86,9 @@ class MinStepGenerator(object):
 
     def __repr__(self):
         class_name = self.__class__.__name__
-        kwds = ['%s=%s' % (name, str(getattr(self, name)))
+        kwds = ['{0!s}={1!s}'.format(name, str(getattr(self, name)))
                 for name in self.__dict__.keys()]
-        return """%s(%s)""" % (class_name, ','.join(kwds))
+        return """{0!s}({1!s})""".format(class_name, ','.join(kwds))
 
     def _default_base_step(self, xi):
         scale = self.scale

--- a/numdifftools/multicomplex.py
+++ b/numdifftools/multicomplex.py
@@ -135,7 +135,7 @@ class bicomplex(object):
 
     def __repr__(self):
         name = self.__class__.__name__
-        return """%s(z1=%s, z2=%s)""" % (name, str(self.z1), str(self.z2))
+        return """{0!s}(z1={1!s}, z2={2!s})""".format(name, str(self.z1), str(self.z2))
 
     def __lt__(self, other):
         other = self._coerce(other)

--- a/numdifftools/run_benchmark.py
+++ b/numdifftools/run_benchmark.py
@@ -71,7 +71,7 @@ def loglimits(data, border=0.05):
 fixed_step = MinStepGenerator(num_steps=1, use_exact_steps=True, offset=0)
 epsilon = MaxStepGenerator(num_steps=14, use_exact_steps=True,
                            step_ratio=1.6, offset=0)
-adaptiv_txt = '_adaptive_%d_%s_%d' % (epsilon.num_steps,
+adaptiv_txt = '_adaptive_{0:d}_{1!s}_{2:d}'.format(epsilon.num_steps,
                                       str(epsilon.step_ratio), epsilon.offset)
 gradient_funs = OrderedDict()
 nda_method = 'forward'

--- a/numdifftools/tests/test_multicomplex.py
+++ b/numdifftools/tests/test_multicomplex.py
@@ -321,7 +321,7 @@ def _test_first_derivative(name):
 
     der = f(bicomplex(x + h * 1j, 0)).imag1 / h
     der_true = df(x)
-    np.testing.assert_allclose(der, der_true, err_msg=('%s' % name))
+    np.testing.assert_allclose(der, der_true, err_msg=('{0!s}'.format(name)))
 
 
 def _test_second_derivative(name):
@@ -332,7 +332,7 @@ def _test_second_derivative(name):
 
     der = f(bicomplex(x + h * 1j, h)).imag12 / h**2
     der_true = df(x)
-    np.testing.assert_allclose(der, der_true, err_msg=('%s' % name))
+    np.testing.assert_allclose(der, der_true, err_msg=('{0!s}'.format(name)))
 
 _function_names = ['cos', 'sin', 'tan', 'arccos', 'arcsin', 'arctan', 'cosh',
                    'sinh', 'tanh', 'exp', 'log', 'exp2', 'square', 'sqrt',


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:pbrod:numdifftools?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:pbrod:numdifftools?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)