### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,10 +191,10 @@ def linkcode_resolve(domain, info):
     fn = relpath(fn, start=dirname(numdifftools.__file__))
 
     if 'dev' in _VERSION:
-        return "http://github.com/pbrod/numdifftools/blob/master/numdifftools/%s%s" % (
+        return "http://github.com/pbrod/numdifftools/blob/master/numdifftools/{0!s}{1!s}".format(
            fn, linespec)
     else:
-        return "http://github.com/pbrod/numdifftools/blob/v%s/numdifftools/%s%s" % (
+        return "http://github.com/pbrod/numdifftools/blob/v{0!s}/numdifftools/{1!s}{2!s}".format(
            _VERSION, fn, linespec)
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:pbrod:numdifftools?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:pbrod:numdifftools?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)