### PR TITLE
Allow fd_derivative to take complex valued functions

### DIFF
--- a/numdifftools/fornberg.py
+++ b/numdifftools/fornberg.py
@@ -164,7 +164,7 @@ def fd_derivative(fx, x, n=1, m=2):
     _assert(n < num_x, 'len(x) must be larger than n')
     _assert(num_x == len(fx), 'len(x) must be equal len(fx)')
 
-    du = np.zeros(np.shape(fx))
+    du = np.zeros_like(fx)
 
     mm = n // 2 + m
     size = 2 * mm + 2  # stencil size at boundary


### PR DESCRIPTION
At the moment the array which stores the derivatives, du, is always real so if the array of function evaluations, fx, is complex then the imaginary part gets discarded when the elements of du are assigned.

``
/usr/local/lib/python3.5/site-packages/numdifftools/fornberg.py:173: ComplexWarning: Casting complex values to real discards the imaginary part
  du[i] = np.dot(fd_weights(x[:size], x0=x[i], n=n), fx[:size])
``

The proposed change fixes this by matching the data type (as well as the shape) of du to fx.

PS thank you for working on this very useful module!