### PR TITLE
Python 3.6 compatibility

### DIFF
--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -1,78 +1,50 @@
 package:
   name: numdifftools
-  version: "0.9.13.post0.dev47+gbce4a58.dirty"
+  version: "0.0.0"
 
 source:
   path: ..
-#  patches:
-   # List any patch files here
-   # - fix.patch
 
-# build:
-  # noarch_python: True
-  # preserve_egg_dir: True
-  # entry_points:
-    # Put any entry points (scripts to be generated automatically) here. The
-    # syntax is module:function.  For example
-    #
-    # - numdifftools = numdifftools:main
-    #
-    # Would create an entry point called numdifftools that calls numdifftools.main()
-
-
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
 
 requirements:
   build:
     - python
     - setuptools
+    - setuptools_scm
+    - pyscaffold
+    - six
     - numpy >=1.9
     - scipy >=0.8
-    - algopy >=0.4
-    - six
-    - pyscaffold
-    - setuptools_scm
+    - algopy >=0.4    [not py36]
+    - statsmodels
 
   run:
     - python
     - setuptools
+    - setuptools_scm
+    - pyscaffold
+    - six
     - numpy >=1.9
     - scipy >=0.8
-    - algopy >=0.4
-    - six
-    - pyscaffold
-    - setuptools_scm
+    - algopy >=0.4    [not py36]
+    - statsmodels
 
 test:
-  # Python imports
-  # imports:
   imports:
     - numdifftools
     - numdifftools.tests
 
 
-  #commands:
-    # You can put test commands to be run here.  Use this to test that the
-    # entry points work.
-    #- python setup.py test
-    #- numdifftools.test()
-
-  # You can also put a file called run_test.py in the recipe that will be run
-  # at test time.
-
   requires:
+    - nose
     - pytest
     - pytest-cov
-    # Put any additional test requirements here.  For example
-    - nose
+    - line_profiler
+    - hypothesis
+    - matplotlib
+
 
 about:
   home: "https://github.com/pbrod/numdifftools/"
   license: new BSD
   summary: "'Solves automatic numerical differentiation problems in one or more variables.'"
-
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml

--- a/conda_recipe/run_test.py
+++ b/conda_recipe/run_test.py
@@ -1,3 +1,10 @@
-import numdifftools
+import os
 
-numdifftools.test()
+import numdifftools
+import pytest
+
+
+path = os.path.join(numdifftools.__path__[0], 'tests')
+os.chdir(path)
+
+pytest.main()

--- a/numdifftools/__init__.py
+++ b/numdifftools/__init__.py
@@ -1,13 +1,4 @@
-import pkg_resources
 from .info import __doc__
 from .core import *
 from . import extrapolation, limits, step_generators
 
-from numpy.testing import Tester
-try:
-    __version__ = pkg_resources.get_distribution(__name__).version
-except pkg_resources.DistributionNotFound:
-    __version__ = 'unknown'
-
-
-test = Tester(raise_warnings="release").test

--- a/numdifftools/tests/test_example_functions.py
+++ b/numdifftools/tests/test_example_functions.py
@@ -1,10 +1,16 @@
 import unittest
 import numpy as np
 import numdifftools.core as nd
-import numdifftools.nd_algopy as nda
 import numdifftools.nd_statsmodels as nds
 from numpy.testing import assert_array_almost_equal
 from numdifftools.example_functions import function_names, get_function
+
+try:
+    import algopy
+except ImportError:
+    nda = None
+else:
+    import numdifftools.nd_algopy as nda
 
 
 class TestExampleFunctions(unittest.TestCase):
@@ -14,7 +20,11 @@ class TestExampleFunctions(unittest.TestCase):
         min_dm = dict(complex=2, forward=2, backward=2, central=4)
         methods = [ 'complex', 'central',  'backward', 'forward']
 
-        for i, derivative in enumerate([nd.Derivative, nda.Derivative]):
+        derivatives = [nd.Derivative]
+        if nda is not None:
+            derivatives.append(nda.Derivative)
+
+        for i, derivative in enumerate(derivatives):
             for name in function_names:
                 if i>0 and name in ['arcsinh', 'exp2']:
                     continue
@@ -37,8 +47,11 @@ class TestExampleFunctions(unittest.TestCase):
         x = 0.5
         min_dm = dict(complex=2, forward=2, backward=2, central=4)
         methods = [ 'complex', 'central',  'backward', 'forward']
+        derivatives = [nd.Derivative, nds.Gradient]
+        if nda is not None:
+            derivatives.append(nda.Derivative)
 
-        for i, derivative in enumerate([nd.Derivative, nds.Gradient, nda.Derivative]):
+        for i, derivative in enumerate(derivatives):
             for name in function_names:
                 if i>1 and name in ['arcsinh', 'exp2']:
                     continue
@@ -54,7 +67,6 @@ class TestExampleFunctions(unittest.TestCase):
                     dm = 7
                     print(i, name, method, dm, np.abs(val-tval))
                     assert_array_almost_equal(val, tval, decimal=dm)
-        # self.assertTrue(False)
 
 
 if __name__ == '__main__':

--- a/numdifftools/tests/test_nd_algopy.py
+++ b/numdifftools/tests/test_nd_algopy.py
@@ -3,13 +3,25 @@
 
 from __future__ import division
 import unittest
-import numdifftools.nd_algopy as nd
+
 import numpy as np
 from numpy.testing import assert_allclose
-import algopy
 from numdifftools.testing import rosen
 from numdifftools.tests.hamiltonian import run_hamiltonian
 from hypothesis import given, example, note, strategies as st
+import pytest
+
+
+try:
+    import algopy
+except ImportError:
+    algopy = None
+else:
+    import numdifftools.nd_algopy as nd
+
+
+pytestmark = pytest.mark.skipif(algopy is None, reason="algopy is not installed!")
+
 
 class TestHessian(unittest.TestCase):
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ PyPi upload:
 import sys
 from setuptools import setup
 
+
 def print_version():
     import pkg_resources
     try:

--- a/tox.ini
+++ b/tox.ini
@@ -31,12 +31,13 @@ commands = flake8 setup.py numdifftools tests
 # Options for pytest
 [pytest]
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
+
 addopts =
-    -rsxXf
-    --doctest-modules
+    -rsx
 
 norecursedirs =
     .*
+    conda_recipe
     _build
     docs
     tmp*


### PR DESCRIPTION
I've opened this PR in case any of the changes I've made here are useful.

The main change I've made is to make algopy an *optional* dependency, and to ignore it on Python 3.6. Given that algopy development has all but stopped I wouldn't want to have a hard dependency on it IMHO.

I explicitly disabled the doctests as they don't work for me.

I also removed the use of `Tester` in the `__init__.py` as that usage seems to be [deprecated](https://github.com/numpy/numpy/blob/master/numpy/__init__.py#L149-L152), broke pytest testing (for me) and IMHO doesn't add much value.

I also updated the `meta.yaml` so the conda build worked for me.
