### PR TITLE
include LICENSE.txt in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ author_email = per.andreas.brodtkorb@gmail.com
 license = new BSD
 home-page = https://github.com/pbrod/numdifftools
 description-file = README.rst
+license-file = LICENSE.txt
 
 # Add here all kinds of additional classifiers as defined under
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
The BSD license requires that redistributions of your package include the license text, but your currently don't. The `MANIFEST.in` change makes the `.tar.gz` files from `sdist` include `LICENSE.txt`, and the `setup.cfg` line does the same for wheels.