### PR TITLE
Avoid _get_logn RuntimeWarning

### DIFF
--- a/src/numdifftools/fornberg.py
+++ b/src/numdifftools/fornberg.py
@@ -210,6 +210,9 @@ def _poor_convergence(z, r, f, bn, mvec):
 
 
 def _get_logn(n):
+    if n == 1:
+        return 0
+
     return np.int_(np.log2(n - 1) - 1.5849625007211561).clip(min=0)
 
 


### PR DESCRIPTION
This is a small issue but running, for example, 
```Python
import numdifftools.fornberg as ndf
f = lambda z: (z-2)**2
ndf.derivative(f, 2.5, n=1)
```
gives the RuntimeWarning
```
  /usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/numdifftools/fornberg.py:213: RuntimeWarning: divide by zero encountered in log2
    return np.int_(np.log2(n - 1) - 1.5849625007211561).clip(min=0)
```
This happens because in the function `_get_logn(n)` when `n=1` it tries to evaluate `np.log2(0)`.  So I propose to capture that particular case and simply return 0 rather than evaluating log2.
