### PR TITLE
Fix numpy future warning

### DIFF
--- a/src/numdifftools/limits.py
+++ b/src/numdifftools/limits.py
@@ -202,9 +202,9 @@ class _Limit(object):
     @staticmethod
     def _vstack(sequence, steps):
         original_shape = np.shape(sequence[0])
-        f_del = np.vstack(list(np.ravel(r)) for r in sequence)
-        h = np.vstack(list(np.ravel(np.ones(original_shape)*step))
-                      for step in steps)
+        f_del = np.vstack([list(np.ravel(r)) for r in sequence])
+        h = np.vstack([list(np.ravel(np.ones(original_shape)*step))
+                      for step in steps])
         _assert(f_del.size == h.size, 'fun did not return data of correct '
                 'size (it must be vectorized)')
         return f_del, h, original_shape


### PR DESCRIPTION
On latest numpy version`1.16.1` get the FutureWarning: 

/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/numdifftools/limits.py:205: FutureWarning: arrays to stack must be passed as a "sequence" type such as list or tuple. Support for non-sequence iterables such as generators is deprecated as of NumPy 1.16 and will raise an error in the future.

A fix for this is to put the generator comprehension in a list.