### PR TITLE
Pass arrays to np.vstack as sequences (fix numpy 1.16 deprecation)

### DIFF
--- a/src/numdifftools/limits.py
+++ b/src/numdifftools/limits.py
@@ -202,9 +202,9 @@ class _Limit(object):
     @staticmethod
     def _vstack(sequence, steps):
         original_shape = np.shape(sequence[0])
-        f_del = np.vstack(list(np.ravel(r)) for r in sequence)
-        h = np.vstack(list(np.ravel(np.ones(original_shape)*step))
-                      for step in steps)
+        f_del = np.vstack([list(np.ravel(r)) for r in sequence])
+        h = np.vstack([list(np.ravel(np.ones(original_shape)*step))
+                      for step in steps])
         _assert(f_del.size == h.size, 'fun did not return data of correct '
                 'size (it must be vectorized)')
         return f_del, h, original_shape


### PR DESCRIPTION
Numpy 1.16 deprecates passing non-sequence iterables to np.[hv]stack.
Numdifftools uses vstack with generators twice in limits.py.
Fix this by using list-comprehensions instead of generators.

Numpy release notes: https://docs.scipy.org/doc/numpy-1.16.0/release.html#new-deprecations