### PR TITLE
improve performance by combining percentile calculations

### DIFF
--- a/src/numdifftools/limits.py
+++ b/src/numdifftools/limits.py
@@ -165,8 +165,7 @@ class _Limit(object):
         """
         try:
             median = np.nanmedian(der, axis=0)
-            p75 = np.nanpercentile(der, 75, axis=0)
-            p25 = np.nanpercentile(der, 25, axis=0)
+            p25, p75 = np.nanpercentile(der, [25, 75], axis=0)
             iqr = np.abs(p75 - p25)
         except ValueError as msg:
             warnings.warn(str(msg))

--- a/src/numdifftools/limits.py
+++ b/src/numdifftools/limits.py
@@ -164,8 +164,11 @@ class _Limit(object):
         trimming factor is defined as a parameter.
         """
         try:
-            median = np.nanmedian(der, axis=0)
-            p25, p75 = np.nanpercentile(der, [25, 75], axis=0)
+            if np.any(np.isnan(der)):
+                p25, median, p75 = np.nanpercentile(der, [25,50, 75], axis=0) 
+            else:
+                p25, median, p75 = np.percentile(der, [25,50, 75], axis=0)
+
             iqr = np.abs(p75 - p25)
         except ValueError as msg:
             warnings.warn(str(msg))


### PR DESCRIPTION
By combining the two calculations the data only needs to sorted (inside `nanpercentile`) once.

On a the testcase below this gives a 15-20% speedup:
```
import numpy as np
import numdifftools as nd
import time

fun = lambda x: np.array([np.sum(x**2), np.sum(x), x[0], x[1]])
dfun = nd.Jacobian(fun)
t0=time.time()
for ii in range(200):  
    dfun([1,2,3])
    dfun([0,2.2,-3])
print(time.time()-t0)
```

Update: `np.nanpercentile` is very slow compared to `np.percentile`. By adding a check on the presence of NaN values we can improve performance by another 10%.

@pbrod 