### PR TITLE
Update python version for CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,31 +2,15 @@ build: off
 
 environment:
   matrix:
-    - PYTHON_VERSION: 2.7
-      MINICONDA: C:\Miniconda
-      PYTHON_ARCH: "32"
-    - PYTHON_VERSION: 2.7
-      MINICONDA: C:\Miniconda-x64
-      PYTHON_ARCH: "64"
-    - PYTHON_VERSION: 3.6
-      MINICONDA: C:\Miniconda36
-      PYTHON_ARCH: "32"
-    - PYTHON_VERSION: 3.6
-      MINICONDA: C:\Miniconda36-x64
-      PYTHON_ARCH: "64"
     - PYTHON_VERSION: 3.7
       MINICONDA: C:\Miniconda37
       PYTHON_ARCH: "32"
     - PYTHON_VERSION: 3.7
       MINICONDA: C:\Miniconda37-x64
       PYTHON_ARCH: "64"
-#    - PYTHON_VERSION: 3.8
-#      MINICONDA: C:\Miniconda38-x64
-#      PYTHON_ARCH: "64"
-#    - PYTHON_VERSION: 3.9
-#      MINICONDA: C:\Miniconda39-x64
-#      PYTHON_ARCH: "64"
-
+    - PYTHON_VERSION: 3.8
+      MINICONDA: C:\Miniconda38-x64
+      PYTHON_ARCH: "64"
 
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ platforms = any
 classifiers =
     Development Status :: 4 - Beta
     Programming Language :: Python
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9


### PR DESCRIPTION
Following up on #62 I removed all python versions from the CI that reached their end of life. I added version 3.8.
In the [appveyor documentation](https://www.appveyor.com/docs/windows-images-software/#miniconda) it looks like miniconda is not available for python 3.9 & 3.10.