### PR TITLE
Feat/GitHub actions ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  pytest:
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -31,6 +31,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install wheel
+          pip install pytest pytest-cov line_profiler hypothesis matplotlib
           pip install .
 
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: test
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        include:
+          - os: macos-latest
+            python-version: 3.9
+          - os: windows-latest
+            python-version: 3.9
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel
+          pip install .
+
+      - name: Run tests
+        run: python conda_recipe/run_test.py


### PR DESCRIPTION
Since the current appveyor/miniconda ci setup does not seem to support newer python versions than 3.7 (see #64)  I propose another lightweight solution via GitHub actions which includes tests for python 3.7, 3.8, 3.9, 3.10 on ubuntu, windows and mac-os.

I did not deactivate the appveyor ci yet and also did not add any coverage report. Tell me what you think @pbrod 