### PR TITLE
maybe a typo

### DIFF
--- a/docs/tutorials/install.rst
+++ b/docs/tutorials/install.rst
@@ -75,7 +75,7 @@ To test if the toolbox is working correctly paste the following in an interactiv
 
 .. parsed-literal::
 
-    nd.test('--doctest-module')
+    nd.test('--doctest-modules')
 
 
 If the result show no errors, you now have installed a fully functional toolbox.


### PR DESCRIPTION
```shell
>>> nd.test('--doctest-module')
ERROR: usage:  [options] [file_or_dir] [file_or_dir] [...]
: error: unrecognized arguments: --doctest-module
  inifile: None
  rootdir: C:\Users\Administrator\Desktop\Deep-Learning-Systems\source_code\hw1

<ExitCode.USAGE_ERROR: 4>
```